### PR TITLE
Add initial FastAPI web app for notebook viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # typetheory
+
+This repository contains an evolving platform for studying type theory using Jupyter notebooks and automated quizzes.
+
+Learning material lives under `notebooks/`. Each document is stored as both a Jupyter notebook (`.ipynb`) and a matching py-percent script (`.py`). Rendered Markdown and HTML are generated from the notebook for easy viewing.
+
+A small FastAPI app (in `app/`) serves these notebooks as HTML and lets you upload new notebooks.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the development server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+3. Open `http://localhost:8000` in your browser to view the available notebooks and upload new ones.
+
+See [ROADMAP.md](ROADMAP.md) for the current development plan.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,69 @@
+# Type Theory Learning Platform Roadmap
+
+This document outlines the planned phases for building a web-based system for learning type theory through Jupyter notebooks. The goal is to allow rendered notebooks to be organized in a dependency graph, quiz users on each document, and eventually incorporate spaced repetition.
+
+## Document Setup (v0.0)
+Before any web interface exists, we maintain the core learning material in a
+structured folder layout. Each document lives in a subdirectory of
+`notebooks/` and contains:
+
+* `NAME.ipynb` – the canonical Jupyter notebook
+* `NAME.py` – the same content in "py percent" format for easier text diffs
+* `NAME.md` – rendered Markdown output
+* `NAME.html` – optional HTML rendering
+
+The Markdown and HTML files are generated from the notebook using `nbconvert`.
+The `.ipynb` or `.py` file with the most recent git timestamp is treated as the
+authoritative source. Version control keeps all representations for review.
+
+Initial documents included:
+
+1. **definitions-overview** – relationships between basic definitions in type
+   theory.
+2. **idea** – motivation for different type theories and why certain rules
+   (like definitional equality) are introduced.
+3. **rule-hierarchy** – grouping of rules and the judgements they interact with.
+
+These provide a small corpus for testing the build process.
+
+## Phase 1: Notebook Rendering & Display (v0.1)
+1. **Notebook Collection**: Place notebooks in the `notebooks/` directory using the structure from *v0.0*.
+2. **Markdown/HTML Rendering**: Use `nbconvert` to generate both `.md` and `.html` from each notebook. Provide a script to update outputs when sources change.
+3. **Web Interface**: Build a lightweight FastAPI app that lists available documents and serves the rendered Markdown/HTML.
+4. **Module Dependencies**: Maintain a small JSON/YAML file describing prerequisite relationships between notebooks to create a DAG of modules.
+
+Checkpoint **A**: HTML rendering works, notebooks can be viewed, and prerequisites are enforced.
+
+## Phase 2: LLM-Generated Quizzes (v0.2)
+1. **Quiz Generation**: Send notebook content to an LLM (e.g., OpenAI GPT) to create quiz questions. Store these in `quizzes/`.
+2. **Quiz Interface**: Add a web page for each notebook's quiz. Track user answers and scores (e.g., SQLite).
+3. **Answer Evaluation**: Send user answers alongside expected answers to the LLM for grading and brief feedback.
+
+Checkpoint **B**: Quizzes generate correctly, scores persist, and progress can be viewed.
+
+## Phase 3: Performance Tracking & Spaced Repetition (v0.3)
+1. **History Database**: Keep a history of quiz attempts with timestamps and scores.
+2. **Scheduling**: Implement a spaced-repetition scheduler (e.g., SM-2) to determine when to review each notebook.
+3. **Dashboard**: Show upcoming reviews and overall performance metrics.
+
+Checkpoint **C**: Spaced repetition is functioning and performance data is recorded.
+
+## Phase 4: Polishing & Deployment (v1.0)
+1. **User Management**: Decide whether to support multiple users or stay single-user.
+2. **Dockerization**: Provide Docker setup for easy deployment to free hosting services.
+3. **CI/CD and Tests**: Add automated tests and setup a simple CI pipeline to run them.
+
+Checkpoint **D**: Final feedback and testing before releasing v1.0.
+
+## Possible Future Enhancements
+- Interactive widgets inside notebooks.
+- Enhanced tutoring features using LLMs.
+- Notifications or integrations for reminders.
+
+## Development Process
+1. Edit notebooks using either the `.ipynb` file in JupyterLab or the corresponding `.py` percent file in a text editor.
+2. Run the build script to regenerate Markdown/HTML outputs via `nbconvert`.
+3. Commit all updated files so the repository tracks both sources and rendered artifacts.
+4. Use feature branches or pull requests to review changes and keep history of the learning material.
+
+This roadmap should guide future contributors or coding agents in implementing the project incrementally.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,57 @@
+from fastapi import FastAPI, UploadFile, File, Form
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from fastapi.staticfiles import StaticFiles
+from starlette.requests import Request
+import nbconvert
+import nbformat
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+NOTEBOOKS_DIR = ROOT / "notebooks"
+TEMPLATES_DIR = ROOT / "templates"
+
+app = FastAPI()
+app.mount("/static", StaticFiles(directory=NOTEBOOKS_DIR), name="static")
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
+
+def list_notebooks():
+    notebooks = []
+    for path in NOTEBOOKS_DIR.iterdir():
+        ipynb = path / f"{path.name}.ipynb"
+        if ipynb.exists():
+            notebooks.append(path.name)
+    return notebooks
+
+
+def render_notebook_html(name: str) -> str:
+    ipynb_path = NOTEBOOKS_DIR / name / f"{name}.ipynb"
+    if not ipynb_path.exists():
+        return "Notebook not found"
+    notebook = nbformat.read(ipynb_path, as_version=4)
+    html_exporter = nbconvert.HTMLExporter()
+    body, _ = html_exporter.from_notebook_node(notebook)
+    return body
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    notebooks = list_notebooks()
+    return templates.TemplateResponse("index.html", {"request": request, "notebooks": notebooks})
+
+
+@app.get("/notebook/{name}", response_class=HTMLResponse)
+async def view_notebook(name: str, request: Request):
+    body = render_notebook_html(name)
+    return templates.TemplateResponse("notebook.html", {"request": request, "body": body, "name": name})
+
+
+@app.post("/api/notebooks")
+async def upload_notebook(name: str = Form(...), file: UploadFile = File(...)):
+    nb_dir = NOTEBOOKS_DIR / name
+    nb_dir.mkdir(exist_ok=True, parents=True)
+    ipynb_path = nb_dir / f"{name}.ipynb"
+    content = await file.read()
+    ipynb_path.write_bytes(content)
+    return {"status": "saved", "path": str(ipynb_path)}

--- a/notebooks/definitions-overview/definitions-overview.html
+++ b/notebooks/definitions-overview/definitions-overview.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><body><h1>Definitions Overview</h1><p>Placeholder notebook.</p></body></html>

--- a/notebooks/definitions-overview/definitions-overview.ipynb
+++ b/notebooks/definitions-overview/definitions-overview.ipynb
@@ -1,0 +1,8 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "metadata": {}, "source": ["# Definitions Overview\n", "Placeholder notebook."]}
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/definitions-overview/definitions-overview.md
+++ b/notebooks/definitions-overview/definitions-overview.md
@@ -1,0 +1,3 @@
+# Definitions Overview
+
+Placeholder notebook.

--- a/notebooks/definitions-overview/definitions-overview.py
+++ b/notebooks/definitions-overview/definitions-overview.py
@@ -1,0 +1,4 @@
+# %% [markdown]
+# # Definitions Overview
+#
+# Placeholder notebook.

--- a/notebooks/idea/idea.html
+++ b/notebooks/idea/idea.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><body><h1>Idea Behind Type Theory</h1><p>Placeholder notebook explaining motivation.</p></body></html>

--- a/notebooks/idea/idea.ipynb
+++ b/notebooks/idea/idea.ipynb
@@ -1,0 +1,8 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "metadata": {}, "source": ["# Idea Behind Type Theory\n", "Placeholder notebook explaining motivation."]}
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/idea/idea.md
+++ b/notebooks/idea/idea.md
@@ -1,0 +1,3 @@
+# Idea Behind Type Theory
+
+Placeholder notebook explaining motivation.

--- a/notebooks/idea/idea.py
+++ b/notebooks/idea/idea.py
@@ -1,0 +1,4 @@
+# %% [markdown]
+# # Idea Behind Type Theory
+#
+# Placeholder notebook explaining motivation.

--- a/notebooks/rule-hierarchy/rule-hierarchy.html
+++ b/notebooks/rule-hierarchy/rule-hierarchy.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><body><h1>Rule Hierarchy</h1><p>Placeholder notebook describing rule groups.</p></body></html>

--- a/notebooks/rule-hierarchy/rule-hierarchy.ipynb
+++ b/notebooks/rule-hierarchy/rule-hierarchy.ipynb
@@ -1,0 +1,8 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "metadata": {}, "source": ["# Rule Hierarchy\n", "Placeholder notebook describing rule groups."]}
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/rule-hierarchy/rule-hierarchy.md
+++ b/notebooks/rule-hierarchy/rule-hierarchy.md
@@ -1,0 +1,3 @@
+# Rule Hierarchy
+
+Placeholder notebook describing rule groups.

--- a/notebooks/rule-hierarchy/rule-hierarchy.py
+++ b/notebooks/rule-hierarchy/rule-hierarchy.py
@@ -1,0 +1,4 @@
+# %% [markdown]
+# # Rule Hierarchy
+#
+# Placeholder notebook describing rule groups.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+jinja2
+nbconvert
+nbformat

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Type Theory Docs</title>
+</head>
+<body>
+<h1>Available Notebooks</h1>
+<ul>
+{% for nb in notebooks %}
+<li><a href="/notebook/{{ nb }}">{{ nb }}</a></li>
+{% endfor %}
+</ul>
+<form action="/api/notebooks" method="post" enctype="multipart/form-data">
+    <h2>Upload Notebook</h2>
+    Name: <input type="text" name="name" />
+    File: <input type="file" name="file" />
+    <button type="submit">Upload</button>
+</form>
+</body>
+</html>

--- a/templates/notebook.html
+++ b/templates/notebook.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ name }}</title>
+</head>
+<body>
+<a href="/">Back</a>
+<h1>{{ name }}</h1>
+<div>{{ body | safe }}</div>
+</body>
+</html>

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,25 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from pathlib import Path
+
+client = TestClient(app)
+
+
+def test_index():
+    r = client.get('/')
+    assert r.status_code == 200
+    assert '<h1>Available Notebooks</h1>' in r.text
+
+
+def test_upload_and_view(tmp_path, monkeypatch):
+    # create a minimal notebook
+    nb_content = '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}'
+    file = tmp_path / 'sample.ipynb'
+    file.write_text(nb_content)
+
+    with open(file, 'rb') as f:
+        r = client.post('/api/notebooks', data={'name': 'sample'}, files={'file': ('sample.ipynb', f, 'application/json')})
+    assert r.status_code == 200
+    r = client.get('/notebook/sample')
+    assert r.status_code == 200
+    assert 'sample' in r.text


### PR DESCRIPTION
## Summary
- build a small FastAPI app for viewing notebooks
- add HTML templates and uploading capability
- document how to run the server locally
- create tests for the FastAPI app

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f9c9b6938832b8ad862e9ab5e5902